### PR TITLE
Add PayPal order creation and capture

### DIFF
--- a/booking/views.py
+++ b/booking/views.py
@@ -18,6 +18,7 @@ import logging
 from event_management.models import Event, TicketType
 from .models import Cart, CartItem, Order, OrderItem, Ticket
 from .utils import send_order_confirmation_email, generate_tickets_pdf, generate_single_ticket_pdf
+from payments.paypal_client import PayPalClient, format_amount
 
 logger = logging.getLogger(__name__)
 
@@ -308,15 +309,29 @@ def create_ticket_order(request):
             'create_account': data.get('create_account', False)
         }
         
-        # TODO: Create real PayPal order here using paypalrestsdk
-        # For now, return mock order
-        user_id = request.user.id if request.user.is_authenticated else 'guest'
-        mock_order_id = f'TICKETS-{user_id}-{timezone.now().timestamp()}'
-        
-        logger.info(f"Creating ticket order: {mock_order_id}, total: £{total}, customer: {data.get('email')}")
-        
+        # Create PayPal order using SDK
+        paypal_client = PayPalClient()
+        order_data = {
+            'amount': format_amount(total),
+            'currency': 'GBP',
+            'description': 'Event ticket purchase',
+            'return_url': request.build_absolute_uri(reverse('booking:checkout')),
+            'cancel_url': request.build_absolute_uri(reverse('booking:checkout')),
+        }
+
+        pp_result = paypal_client.create_order(order_data)
+
+        if not pp_result.get('success'):
+            logger.error(f"PayPal order creation failed: {pp_result.get('error')}")
+            return JsonResponse({'error': 'Failed to create PayPal order'}, status=500)
+
+        order_id = pp_result.get('order_id')
+        logger.info(
+            f"Creating ticket order: {order_id}, total: £{total}, customer: {data.get('email')}"
+        )
+
         return JsonResponse({
-            'id': mock_order_id,
+            'id': order_id,
             'amount': str(total)
         })
         
@@ -348,9 +363,20 @@ def capture_ticket_payment(request):
         if cart.total_items == 0:
             return JsonResponse({'error': 'Cart is empty'}, status=400)
         
-        # TODO: Verify payment with PayPal API
-        # For now, just create the order
-        
+        # Verify and capture the payment with PayPal
+        paypal_client = PayPalClient()
+        capture_result = paypal_client.capture_order(order_id)
+
+        if not capture_result.get('success') or capture_result.get('status') != 'COMPLETED':
+            logger.error(
+                f"PayPal capture failed for {order_id}: {capture_result.get('error')}"
+            )
+            return JsonResponse({'error': 'Payment verification failed'}, status=400)
+
+        payer_id = None
+        if capture_result.get('response') and getattr(capture_result['response'], 'payer', None):
+            payer_id = capture_result['response'].payer.payer_id
+
         # Create booking order
         with transaction.atomic():
             order = Order.objects.create(
@@ -360,6 +386,8 @@ def capture_ticket_payment(request):
                 last_name=checkout_data.get('last_name'),
                 phone=checkout_data.get('phone', ''),
                 paypal_order_id=order_id,
+                paypal_capture_id=capture_result.get('capture_id', ''),
+                paypal_payer_id=payer_id or '',
                 status='confirmed',
                 paid_at=timezone.now(),
                 total_amount=cart.total_price


### PR DESCRIPTION
## Summary
- implement PayPal order creation in booking views
- capture and verify PayPal payment before confirming orders
- log PayPal failures for easier troubleshooting

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement amqp==5.3.1)*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68740ecf9a488323ae1edcbf529fa7ff