### PR TITLE
Implement PayPal platform service

### DIFF
--- a/payments/paypal_platform.py
+++ b/payments/paypal_platform.py
@@ -1,22 +1,78 @@
 # payments/paypal_platform.py - Complete implementation
+import logging
+
 import paypalrestsdk
 from django.conf import settings
-import logging
 
 logger = logging.getLogger(__name__)
 
+
 class PayPalPlatformService:
     def __init__(self):
-        paypalrestsdk.configure({
-            "mode": settings.PAYPAL_MODE,
-            "client_id": settings.PAYPAL_CLIENT_ID,
-            "client_secret": settings.PAYPAL_CLIENT_SECRET
-        })
-    
+        paypalrestsdk.configure(
+            {
+                "mode": settings.PAYPAL_MODE,
+                "client_id": settings.PAYPAL_CLIENT_ID,
+                "client_secret": settings.PAYPAL_CLIENT_SECRET,
+            }
+        )
+
     def create_order(self, event, pricing_plan):
-        # Full implementation needed
-        pass
-    
+        """Create a PayPal order for an event listing plan."""
+        try:
+            payment = paypalrestsdk.Payment(
+                {
+                    "intent": "sale",
+                    "payer": {"payment_method": "paypal"},
+                    "redirect_urls": {
+                        "return_url": f"{settings.SITE_URL}/payments/platform/success",
+                        "cancel_url": f"{settings.SITE_URL}/payments/platform/cancel",
+                    },
+                    "transactions": [
+                        {
+                            "amount": {
+                                "total": f"{pricing_plan.price_per_event:.2f}",
+                                "currency": "GBP",
+                            },
+                            "description": f"Listing fee for {event.title}",
+                        }
+                    ],
+                }
+            )
+
+            if payment.create():
+                approval_url = next(
+                    (link.href for link in payment.links if link.rel == "approval_url"),
+                    None,
+                )
+                logger.info("Created PayPal order %s", payment.id)
+                return {
+                    "success": True,
+                    "order_id": payment.id,
+                    "approval_url": approval_url,
+                }
+
+            logger.error("PayPal order creation failed: %s", payment.error)
+            return {"success": False, "error": payment.error}
+
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.exception("PayPal order creation error")
+            return {"success": False, "error": str(exc)}
+
     def capture_order(self, order_id):
-        # Full implementation needed
-        pass
+        """Capture an approved PayPal order."""
+        try:
+            payment = paypalrestsdk.Payment.find(order_id)
+            payer_id = payment.payer.payer_info.payer_id
+
+            if payment.execute({"payer_id": payer_id}):
+                sale = payment.transactions[0].related_resources[0].sale
+                logger.info("Captured PayPal order %s", order_id)
+                return {"success": True, "capture_id": sale.id}
+
+            logger.error("PayPal order capture failed: %s", payment.error)
+            return {"success": False, "error": payment.error}
+
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.exception("PayPal order capture error")
+            return {"success": False, "error": str(exc)}

--- a/payments/tests.py
+++ b/payments/tests.py
@@ -1,3 +1,83 @@
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
 from django.test import TestCase
 
-# Create your tests here.
+from payments.paypal_platform import PayPalPlatformService
+
+
+class PayPalPlatformServiceTests(TestCase):
+    """Tests for PayPalPlatformService order creation and capture."""
+
+    @patch("payments.paypal_platform.paypalrestsdk.Payment")
+    def test_create_order_success(self, MockPayment):
+        instance = MockPayment.return_value
+        instance.create.return_value = True
+        instance.id = "PAYID-1"
+        instance.links = [
+            SimpleNamespace(rel="approval_url", href="http://example.com/approve")
+        ]
+
+        service = PayPalPlatformService()
+        event = SimpleNamespace(title="Test Event")
+        plan = SimpleNamespace(price_per_event=Decimal("10.00"))
+
+        result = service.create_order(event, plan)
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["order_id"], "PAYID-1")
+        self.assertEqual(result["approval_url"], "http://example.com/approve")
+        instance.create.assert_called_once()
+
+    @patch("payments.paypal_platform.paypalrestsdk.Payment")
+    def test_create_order_failure(self, MockPayment):
+        instance = MockPayment.return_value
+        instance.create.return_value = False
+        instance.error = {"message": "fail"}
+
+        service = PayPalPlatformService()
+        event = SimpleNamespace(title="Test Event")
+        plan = SimpleNamespace(price_per_event=Decimal("10.00"))
+
+        result = service.create_order(event, plan)
+
+        self.assertFalse(result["success"])
+        self.assertIn("error", result)
+        instance.create.assert_called_once()
+
+    @patch("payments.paypal_platform.paypalrestsdk.Payment")
+    def test_capture_order_success(self, MockPayment):
+        mock_payment = MockPayment.find.return_value
+        mock_payment.payer = SimpleNamespace(
+            payer_info=SimpleNamespace(payer_id="PAYER1")
+        )
+        mock_payment.execute.return_value = True
+        mock_sale = MagicMock(id="SALE1")
+        mock_related = MagicMock(sale=mock_sale)
+        mock_payment.transactions = [MagicMock(related_resources=[mock_related])]
+
+        service = PayPalPlatformService()
+        result = service.capture_order("ORDER1")
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["capture_id"], "SALE1")
+        mock_payment.execute.assert_called_once_with({"payer_id": "PAYER1"})
+        MockPayment.find.assert_called_once_with("ORDER1")
+
+    @patch("payments.paypal_platform.paypalrestsdk.Payment")
+    def test_capture_order_failure(self, MockPayment):
+        mock_payment = MockPayment.find.return_value
+        mock_payment.payer = SimpleNamespace(
+            payer_info=SimpleNamespace(payer_id="PAYER1")
+        )
+        mock_payment.execute.return_value = False
+        mock_payment.error = {"message": "error"}
+
+        service = PayPalPlatformService()
+        result = service.capture_order("ORDER1")
+
+        self.assertFalse(result["success"])
+        self.assertIn("error", result)
+        mock_payment.execute.assert_called_once_with({"payer_id": "PAYER1"})
+        MockPayment.find.assert_called_once_with("ORDER1")


### PR DESCRIPTION
## Summary
- implement PayPalPlatformService.create_order and capture_order
- add tests covering PayPalPlatformService

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest payments/tests.py -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6874129880a48323b0da86f2137b9559