### PR TITLE
Secure order views

### DIFF
--- a/booking/views.py
+++ b/booking/views.py
@@ -2,7 +2,6 @@ from django.shortcuts import render, redirect, get_object_or_404
 from django.contrib.auth.decorators import login_required
 from django.http import JsonResponse, HttpResponse, HttpResponseForbidden
 from django.views.decorators.http import require_POST
-from django.views.decorators.csrf import csrf_exempt
 from django.contrib import messages
 from django.urls import reverse
 from django.db import transaction, models
@@ -280,7 +279,6 @@ def checkout_view(request):
 
 
 @require_POST
-@csrf_exempt
 def create_ticket_order(request):
     """Create PayPal order for ticket purchase"""
     try:
@@ -328,7 +326,6 @@ def create_ticket_order(request):
 
 
 @require_POST
-@csrf_exempt
 def capture_ticket_payment(request):
     """Capture PayPal payment for tickets - FIXED for TicketType"""
     try:

--- a/templates/base.html
+++ b/templates/base.html
@@ -31,9 +31,24 @@
     
     <!-- HTMX Configuration -->
     <script>
+        function getCookie(name) {
+            let cookieValue = null;
+            if (document.cookie && document.cookie !== '') {
+                const cookies = document.cookie.split(';');
+                for (let i = 0; i < cookies.length; i++) {
+                    const cookie = cookies[i].trim();
+                    if (cookie.substring(0, name.length + 1) === (name + '=')) {
+                        cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+                        break;
+                    }
+                }
+            }
+            return cookieValue;
+        }
+
         // Add CSRF token to all HTMX requests
         document.addEventListener('htmx:configRequest', (event) => {
-            event.detail.headers['X-CSRFToken'] = '{{ csrf_token }}';
+            event.detail.headers['X-CSRFToken'] = getCookie('csrftoken');
         });
     </script>
 

--- a/templates/booking/checkout.html
+++ b/templates/booking/checkout.html
@@ -178,6 +178,21 @@
 <script src="https://www.paypal.com/sdk/js?client-id={{ paypal_client_id }}&currency=GBP"></script>
 
 <script>
+function getCookie(name) {
+    let cookieValue = null;
+    if (document.cookie && document.cookie !== '') {
+        const cookies = document.cookie.split(';');
+        for (let i = 0; i < cookies.length; i++) {
+            const cookie = cookies[i].trim();
+            if (cookie.substring(0, name.length + 1) === (name + '=')) {
+                cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+                break;
+            }
+        }
+    }
+    return cookieValue;
+}
+
 // PayPal Smart Payment Buttons
 paypal.Buttons({
     // Called when user clicks the PayPal button
@@ -217,7 +232,7 @@ paypal.Buttons({
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
-                'X-CSRFToken': '{{ csrf_token }}'
+                'X-CSRFToken': getCookie('csrftoken')
             },
             body: JSON.stringify(customerData)
         })
@@ -248,7 +263,7 @@ paypal.Buttons({
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
-                'X-CSRFToken': '{{ csrf_token }}'
+                'X-CSRFToken': getCookie('csrftoken')
             },
             body: JSON.stringify({
                 order_id: data.orderID


### PR DESCRIPTION
## Summary
- remove CSRF exemptions from ticket payment views
- add cookie-based CSRF handling in templates

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687412c2775083238d51f55de4f08c56